### PR TITLE
fix: ensure uint32 before comparison

### DIFF
--- a/codec/buffer.go
+++ b/codec/buffer.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Luke Murphy
+//
+// SPDX-License-Identifier: MIT
+
+//go:build !386 || !arm
+// +build !386 !arm
+
+package codec
+
+import (
+	"math"
+)
+
+const maxBufferSize = math.MaxUint32

--- a/codec/buffer_32bit.go
+++ b/codec/buffer_32bit.go
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2022 Luke Murphy
+//
+// SPDX-License-Identifier: MIT
+
+//go:build 386 || arm
+// +build 386 arm
+
+package codec
+
+import (
+	"math"
+)
+
+const maxBufferSize = math.MaxInt

--- a/codec/writer.go
+++ b/codec/writer.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 	"sync"
 )
 
@@ -24,7 +23,7 @@ func NewWriter(w io.Writer) *Writer { return &Writer{w: w} }
 // WritePacket creates an header for the Packet and writes it and the body to the underlying writer
 func (w *Writer) WritePacket(r Packet) error {
 	bodyLen := len(r.Body)
-	if bodyLen > math.MaxUint32 {
+	if bodyLen > maxBufferSize {
 		return fmt.Errorf("pkt-codec: body too large (%d)", bodyLen)
 	}
 


### PR DESCRIPTION
~~Awaits merging https://github.com/ssbc/go-muxrpc/pull/14 to ensure things are working. Can rebase.~~ Done.

Closes https://github.com/ssbc/go-muxrpc/issues/13.