### PR TITLE
fix: use arch appropriate buffer sizes

### DIFF
--- a/codec/buffer_32bit.go
+++ b/codec/buffer_32bit.go
@@ -7,8 +7,4 @@
 
 package codec
 
-import (
-	"math"
-)
-
-const maxBufferSize = math.MaxInt
+const maxBufferSize = 1 << 30

--- a/codec/writer_test.go
+++ b/codec/writer_test.go
@@ -6,7 +6,6 @@ package codec
 
 import (
 	"bytes"
-	"math"
 	"os/exec"
 	"testing"
 
@@ -54,7 +53,7 @@ func TestWriteTooLarge(t *testing.T) {
 	w := NewWriter(in)
 
 	large := Packet{
-		Body: bytes.Repeat([]byte{0}, math.MaxUint32+1),
+		Body: bytes.Repeat([]byte{0}, maxBufferSize+1),
 	}
 
 	err := w.WritePacket(large)


### PR DESCRIPTION
Another one for https://github.com/ssbc/go-muxrpc/issues/13.

Follows approach of https://github.com/dgraph-io/ristretto/pull/238 - we limit the buffer size to something still big but in range for 32 bit archs. I don't have a 32 bit machine to test this range but the PR above shows another large / in-production project using buffer size, so it seems legit :woman_shrugging: 